### PR TITLE
fix(config): add a config option for base path

### DIFF
--- a/docs/env.md
+++ b/docs/env.md
@@ -21,7 +21,7 @@
 | GKB_PORT      | 8080    | Port for the API to start on                                                                                      |
 | GKB_KEY_FILE  | id_rsa  | Path to the private key to use for generating tokens                                                              |
 | GKB_LOG_LEVEL | info    | The level of information to log to the screen and log files                                                       |
-| GKB_BASE_PATH | /       | The base path for requests to the API. This should be changed if you are serving the API from a subdirectory/path |
+| GKB_BASE_PATH |         | The base path for requests to the API. This should be changed if you are serving the API from a subdirectory/path |
 
 ## Key Cloak Settings
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -16,11 +16,12 @@
 
 ## API Settings
 
-| Variable      | Default | Description                                                 |
-| ------------- | ------- | ----------------------------------------------------------- |
-| GKB_PORT      | 8080    | Port for the API to start on                                |
-| GKB_KEY_FILE  | id_rsa  | Path to the private key to use for generating tokens        |
-| GKB_LOG_LEVEL | info    | The level of information to log to the screen and log files |
+| Variable      | Default | Description                                                                                                       |
+| ------------- | ------- | ----------------------------------------------------------------------------------------------------------------- |
+| GKB_PORT      | 8080    | Port for the API to start on                                                                                      |
+| GKB_KEY_FILE  | id_rsa  | Path to the private key to use for generating tokens                                                              |
+| GKB_LOG_LEVEL | info    | The level of information to log to the screen and log files                                                       |
+| GKB_BASE_PATH | /       | The base path for requests to the API. This should be changed if you are serving the API from a subdirectory/path |
 
 ## Key Cloak Settings
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,7 @@
+// All settings in this file are overloadable via environment variables at runtime
 module.exports = {
     common: {
+        GKB_BASE_PATH: '',
         GKB_CORS_ORIGIN: '^.*$',
         GKB_DBS_USER: 'root',
         GKB_DB_CREATE: true,

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ class AppServer {
 
         // set up the routes
         this.router = express.Router();
-        this.prefix = `${conf.GKB_BASE_PATH}/api`;
+        this.prefix = `${conf.GKB_BASE_PATH || ''}/api`;
         this.app.use(this.prefix, this.router);
 
         if (conf.GKB_LOG_LEVEL) {

--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,7 @@ class AppServer {
         this.app.use(bodyParser.urlencoded({ extended: true }));
         this.app.use(bodyParser.json());
         this.app.use(compression());
-        this.app.use('/public', express.static(path.join(__dirname, 'static')));
+        this.app.use(`${conf.GKB_BASE_PATH || ''}/public`, express.static(path.join(__dirname, 'static')));
 
         // add some basic logging
         const originWhiteList = (conf.GKB_CORS_ORIGIN || '.*').split(/[\s,]+/g).map((patt) => {
@@ -113,7 +113,7 @@ class AppServer {
 
         // set up the routes
         this.router = express.Router();
-        this.prefix = '/api';
+        this.prefix = `${conf.GKB_BASE_PATH}/api`;
         this.app.use(this.prefix, this.router);
 
         if (conf.GKB_LOG_LEVEL) {


### PR DESCRIPTION
adds the config option to allow the API to serve from a subdirectory

This fixes an issue with the swagger docs on the demo server. Try https://pori-demo.bcgsc.ca/graphkb-api/api/spec to see the current issue

Note: this has no impact on the regular production deployment. It only affects routing when the new config option is used