### PR TITLE
Refactor/use typescript dependencies

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -29,7 +29,7 @@ jobs:
       - run: npm ci
       - run: npm run lint -- --quiet # errors only, no warnings
         name: eslint
-      - run: npm audit --production --audit-level=high
+      - run: npm audit --production --audit-level=critical
       - run: npm run test
         env:
           GKB_DB_HOST: localhost

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -39,13 +39,13 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           files: coverage/junit.xml
-        if: matrix.node == 12 && matrix.orientdb == '3.0'
+        if: matrix.node == 16 && matrix.orientdb == '3.0'
       - uses: codecov/codecov-action@v1
         with:
           yml: codecov.yml
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_if_ci_error: true
-        if: matrix.node == 12 && matrix.orientdb == '3.0'
+        if: matrix.node == 16 && matrix.orientdb == '3.0'
   docker:
     runs-on: ubuntu-latest
     name: docker build

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,11 @@
   "packages": {
     "": {
       "name": "@bcgsc-pori/graphkb-api",
-      "version": "3.13.3",
+      "version": "3.13.4",
       "license": "GPL-3.0",
       "dependencies": {
-        "@bcgsc-pori/graphkb-parser": "^1.1.2",
-        "@bcgsc-pori/graphkb-schema": "^3.15.0",
+        "@bcgsc-pori/graphkb-parser": "^2.0.0",
+        "@bcgsc-pori/graphkb-schema": "^3.16.0",
         "ajv": "^6.10.2",
         "body-parser": "^1.18.3",
         "compression": "^1.7.4",
@@ -52,6 +52,70 @@
         "jest-junit": "^13.0.0",
         "js-beautify": "^1.10.0",
         "qs": "^6.5.2"
+      }
+    },
+    "../../pori/pori_graphkb_schema": {
+      "name": "@bcgsc-pori/graphkb-schema",
+      "version": "3.16.0",
+      "extraneous": true,
+      "license": "GPL-3.0",
+      "dependencies": {
+        "isemail": "^3.2.0",
+        "lodash.omit": "4.5.0",
+        "typescript": "^4.5.5",
+        "uuid": "3.3.2",
+        "uuid-validate": "0.0.3"
+      },
+      "devDependencies": {
+        "@types/jest": "^27.4.0",
+        "@types/lodash.omit": "^4.5.6",
+        "@types/uuid": "^8.3.4",
+        "@types/uuid-validate": "0.0.1",
+        "@typescript-eslint/eslint-plugin": "^5.10.2",
+        "@typescript-eslint/parser": "^5.10.2",
+        "eslint": "^8.8.0",
+        "eslint-config-airbnb-base": "^15.0.0",
+        "eslint-config-airbnb-typescript": "^16.1.0",
+        "eslint-import-resolver-typescript": "^2.5.0",
+        "eslint-plugin-import": "^2.25.4",
+        "eslint-plugin-jest": "^26.0.0",
+        "eslint-plugin-jest-formatting": "^3.1.0",
+        "jest": "^27.3.1",
+        "jest-circus": "^25.1.0",
+        "jest-environment-node": "^25.1.0",
+        "jest-junit": "^13.0.0",
+        "ts-jest": "^27.1.3"
+      },
+      "peerDependencies": {
+        "@bcgsc-pori/graphkb-parser": ">=2.0.0 <3.0.0"
+      }
+    },
+    "../knowledgebase_schema": {
+      "name": "@bcgsc-pori/graphkb-schema",
+      "version": "3.15.0",
+      "extraneous": true,
+      "license": "GPL-3.0",
+      "dependencies": {
+        "isemail": "^3.2.0",
+        "lodash.omit": "4.5.0",
+        "uuid": "3.3.2",
+        "uuid-validate": "0.0.3"
+      },
+      "devDependencies": {
+        "eslint": "^5.16.0",
+        "eslint-config-airbnb": "^17.1.0",
+        "eslint-plugin-import": "^2.18.0",
+        "eslint-plugin-jest": "^23.6.0",
+        "eslint-plugin-jest-formatting": "^1.2.0",
+        "eslint-plugin-jsx-a11y": "^6.2.3",
+        "eslint-plugin-react": "^7.14.2",
+        "jest": "^24.9.0",
+        "jest-circus": "^25.1.0",
+        "jest-environment-node": "^25.1.0",
+        "jest-junit": "^10.0.0"
+      },
+      "peerDependencies": {
+        "@bcgsc-pori/graphkb-parser": ">=1.1.2 <2.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -652,26 +716,26 @@
       }
     },
     "node_modules/@bcgsc-pori/graphkb-parser": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@bcgsc-pori/graphkb-parser/-/graphkb-parser-1.1.2.tgz",
-      "integrity": "sha512-zpQHe2GI7SyGtDcXLstnvp4Fc6ORakf6QwAkGYCvuZJ4iRSmZJI18XXbEvONPK14a25EmNL9ZXMf/j+lHd3Oyw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@bcgsc-pori/graphkb-parser/-/graphkb-parser-2.0.0.tgz",
+      "integrity": "sha512-LCEPihfDW6FjH83JDDWUg1BQlUN07AGw4smfVv9Bl0L+zgD6BEFPk7oCSZJ5zI3SobP14B279uH7PsXnrS97Sg==",
       "dependencies": {
         "json-cycle": "^1.3.0"
       }
     },
     "node_modules/@bcgsc-pori/graphkb-schema": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@bcgsc-pori/graphkb-schema/-/graphkb-schema-3.15.0.tgz",
-      "integrity": "sha512-PtExjqjrimUd9faE7nx9vdPDVzfzPR17wQOa3lyBIVOD51DQeHwzr+bsf5TmuvJJpG0KhhyGobbBVyekJK/0Ow==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@bcgsc-pori/graphkb-schema/-/graphkb-schema-3.16.0.tgz",
+      "integrity": "sha512-oSEt1ptSRXqG872hEu4GCtjuEhnNVuVJonmrZEQjVrFQb+IGmhFLdYTrKTD8L56AHP/AuHOutrHMpYK5O6HZxQ==",
       "dependencies": {
-        "@bcgsc-pori/graphkb-parser": "^1.1.2",
         "isemail": "^3.2.0",
         "lodash.omit": "4.5.0",
+        "typescript": "^4.5.5",
         "uuid": "3.3.2",
         "uuid-validate": "0.0.3"
       },
       "peerDependencies": {
-        "@bcgsc-pori/graphkb-parser": ">=1.1.2 <2.0.0"
+        "@bcgsc-pori/graphkb-parser": "^2.0.0"
       }
     },
     "node_modules/@bcgsc-pori/graphkb-schema/node_modules/uuid": {
@@ -6657,9 +6721,9 @@
       }
     },
     "node_modules/inquirer/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -10642,9 +10706,9 @@
       "dev": true
     },
     "node_modules/json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -10713,17 +10777,17 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "engines": [
-        "node >=0.6.0"
-      ],
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -14341,11 +14405,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
-      "dev": true,
-      "optional": true,
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15515,21 +15577,21 @@
       }
     },
     "@bcgsc-pori/graphkb-parser": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@bcgsc-pori/graphkb-parser/-/graphkb-parser-1.1.2.tgz",
-      "integrity": "sha512-zpQHe2GI7SyGtDcXLstnvp4Fc6ORakf6QwAkGYCvuZJ4iRSmZJI18XXbEvONPK14a25EmNL9ZXMf/j+lHd3Oyw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@bcgsc-pori/graphkb-parser/-/graphkb-parser-2.0.0.tgz",
+      "integrity": "sha512-LCEPihfDW6FjH83JDDWUg1BQlUN07AGw4smfVv9Bl0L+zgD6BEFPk7oCSZJ5zI3SobP14B279uH7PsXnrS97Sg==",
       "requires": {
         "json-cycle": "^1.3.0"
       }
     },
     "@bcgsc-pori/graphkb-schema": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@bcgsc-pori/graphkb-schema/-/graphkb-schema-3.15.0.tgz",
-      "integrity": "sha512-PtExjqjrimUd9faE7nx9vdPDVzfzPR17wQOa3lyBIVOD51DQeHwzr+bsf5TmuvJJpG0KhhyGobbBVyekJK/0Ow==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@bcgsc-pori/graphkb-schema/-/graphkb-schema-3.16.0.tgz",
+      "integrity": "sha512-oSEt1ptSRXqG872hEu4GCtjuEhnNVuVJonmrZEQjVrFQb+IGmhFLdYTrKTD8L56AHP/AuHOutrHMpYK5O6HZxQ==",
       "requires": {
-        "@bcgsc-pori/graphkb-parser": "^1.1.2",
         "isemail": "^3.2.0",
         "lodash.omit": "4.5.0",
+        "typescript": "^4.5.5",
         "uuid": "3.3.2",
         "uuid-validate": "0.0.3"
       },
@@ -20204,9 +20266,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
           "dev": true
         },
         "strip-ansi": {
@@ -23238,9 +23300,9 @@
       "dev": true
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -23301,13 +23363,13 @@
       }
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },
@@ -26181,11 +26243,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
-      "dev": true,
-      "optional": true
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg=="
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "email": "graphkb@bcgsc.ca"
   },
   "license": "GPL-3.0",
-  "description": "GraphKB (Knowledgebase) REST API server",
+  "description": "GraphKB (Knowledge Base) REST API server",
   "dependencies": {
     "@bcgsc-pori/graphkb-parser": "^2.0.0",
     "@bcgsc-pori/graphkb-schema": "^3.16.0",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "license": "GPL-3.0",
   "description": "GraphKB (Knowledgebase) REST API server",
   "dependencies": {
-    "@bcgsc-pori/graphkb-parser": "^1.1.2",
-    "@bcgsc-pori/graphkb-schema": "^3.15.0",
+    "@bcgsc-pori/graphkb-parser": "^2.0.0",
+    "@bcgsc-pori/graphkb-schema": "^3.16.0",
     "ajv": "^6.10.2",
     "body-parser": "^1.18.3",
     "compression": "^1.7.4",

--- a/src/repo/commands/create.js
+++ b/src/repo/commands/create.js
@@ -1,6 +1,6 @@
 const {
     error: { AttributeError },
-    schema: { schema: SCHEMA_DEFN },
+    schema,
     constants: { PERMISSIONS },
 } = require('@bcgsc-pori/graphkb-schema');
 const { logger } = require('../logging');
@@ -28,12 +28,12 @@ const createUser = async (db, opt) => {
     const groupIds = Array.from(userGroups.filter(
         (group) => groupNames.includes(group.name),
     ), (group) => group['@rid']);
-    const record = SCHEMA_DEFN.User.formatRecord({
+    const record = schema.models.User.formatRecord({
         groups: groupIds,
         name: userName,
         signedLicenseAt: opt.signedLicenseAt || null,
     }, { addDefaults: true, dropExtra: false });
-    await db.insert().into(SCHEMA_DEFN.User.name)
+    await db.insert().into(schema.models.User.name)
         .set(record)
         .one();
 

--- a/src/repo/commands/select.js
+++ b/src/repo/commands/select.js
@@ -10,7 +10,7 @@ const {
     sentenceTemplates: { chooseDefaultTemplate },
     util: { castToRID },
 } = require('@bcgsc-pori/graphkb-schema');
-const { variant: { VariantNotation } } = require('@bcgsc-pori/graphkb-parser');
+const { stringifyVariant } = require('@bcgsc-pori/graphkb-parser');
 
 const { logger } = require('../logging');
 const { parse } = require('../query_builder');
@@ -216,7 +216,7 @@ const fetchDisplayName = async (db, model, content) => {
                 reference2: reference2 && reference2.displayName,
                 type: content.hgvsType || type.shortName || type.displayName,
             };
-            const notation = VariantNotation.toString(obj);
+            const notation = stringifyVariant(obj);
             return notation;
         }
     } if (model.name === 'Statement') {

--- a/src/repo/error.js
+++ b/src/repo/error.js
@@ -1,4 +1,4 @@
-const { error: { ErrorMixin } } = require('@bcgsc-pori/graphkb-parser');
+const { ErrorMixin } = require('@bcgsc-pori/graphkb-parser');
 const { error: { AttributeError } } = require('@bcgsc-pori/graphkb-schema');
 
 class ParsingError extends ErrorMixin {}

--- a/src/repo/index.js
+++ b/src/repo/index.js
@@ -1,6 +1,6 @@
 const { OrientDBClient } = require('orientjs');
 
-const { util: { timeStampNow }, schema: { schema: SCHEMA_DEFN } } = require('@bcgsc-pori/graphkb-schema');
+const { util: { timeStampNow }, schema } = require('@bcgsc-pori/graphkb-schema');
 
 const { logger } = require('./logging');
 const { loadSchema, createSchema } = require('./schema');
@@ -156,10 +156,8 @@ const connectDB = async ({
         throw err;
     }
 
-    let schema;
-
     try {
-        schema = await loadSchema(session);
+        await loadSchema(session);
     } catch (err) {
         logger.error(err);
         session.close();
@@ -167,7 +165,7 @@ const connectDB = async ({
     }
     session.close();
     // create the admin user
-    return { pool, schema, server };
+    return { pool, schema: schema.models, server };
 };
 
 /**
@@ -185,9 +183,9 @@ const incrementUserVisit = async (db, username) => {
     }
     await update(db, {
         changes,
-        model: SCHEMA_DEFN.User,
+        model: schema.models.User,
         paranoid: false,
-        query: parseRecord(SCHEMA_DEFN.User, { '@rid': userRecord['@rid'] }),
+        query: parseRecord(schema.models.User, { '@rid': userRecord['@rid'] }),
         user: userRecord,
     });
 };

--- a/src/repo/migrate/index.js
+++ b/src/repo/migrate/index.js
@@ -660,6 +660,7 @@ const migrate = async (db, opt = {}) => {
         ['3.12.0', '3.13.0', migrate3xFrom12xto13x],
         ['3.13.0', '3.14.0', migrate3xFrom13xto14x],
         ['3.14.0', '3.15.0', migrate3xFrom14xto15x],
+        ['3.15.0', '3.16.0', async () => null], // no db migration required
     ];
 
     while (requiresMigration(migratedVersion, targetVersion)) {

--- a/src/repo/query_builder/fixed.js
+++ b/src/repo/query_builder/fixed.js
@@ -11,8 +11,8 @@ const {
     error: { AttributeError }, schema: { schema },
 } = require('@bcgsc-pori/graphkb-schema');
 const {
-    variant: { parse: parseVariant },
-    error: { ParsingError },
+    parseVariant,
+    ParsingError,
 } = require('@bcgsc-pori/graphkb-parser');
 const { quoteWrap } = require('../util');
 

--- a/src/repo/schema.js
+++ b/src/repo/schema.js
@@ -4,10 +4,9 @@
 /**
  * @ignore
  */
-const _ = require('lodash');
 
 const { RID } = require('orientjs');
-const { constants, schema: { schema: SCHEMA_DEFN }, util: { timeStampNow } } = require('@bcgsc-pori/graphkb-schema');
+const { constants, schema, util: { timeStampNow } } = require('@bcgsc-pori/graphkb-schema');
 
 constants.RID = RID; // IMPORTANT: Without this all castToRID will do is convert to a string
 
@@ -24,47 +23,6 @@ const DEFAULT_LICENSE_CONTENT = [
     { content: 'In no event shall Canada\'s Michael Smith Genome Sciences Centre be liable for any damages or other liability to you or any other users of the GraphKB platform. To the maximum extent permitted by law, in no event shall Canada\'s Michael Smith Genome Sciences Centre or any of its affiliates be liable for any special, punitive, indirect, incidental or consequential damages, including but not limited to personal injury, wrongful death, loss of goodwill, loss of use, loss of profits, interruption of service or loss of data, whether in any action in warranty, contract, tort or any other theory of liability (including, but not limited to negligence or fundamental breach), or otherwise arising out of or in any way connected with the use of, reliance on, or the inability to use, the GraphKB platform or any service offered through the GraphKB platform or any material or information contained in, accessed through, or information, products or services obtained through this platform, even if an authorized representative of GraphKB or Canada\'s Michael Smith Genome Sciences Centre is advised of the likelihood or possibility of the same. To the extent any of the above limitations of liability are restricted by applicable federal, state or local law, such limitations shall not apply to the extent of such restrictions.', id: 'limits', label: 'Limitation of Liability' },
     { content: 'Canada\'s Michael Smith Genome Sciences Centre reserves the right, at its sole discretion, to amend these Terms of Use at any time and will update these Terms of Use in the event of any such amendments. Users are expected to periodically check the Terms of Use for any amendments, but Canada\'s Michael Smith Genome Sciences Centre will take reasonable steps to notify users of significant material changes. Users continued use of the platform and/or the services following such changes shall constitute their affirmative acknowledgment of the Terms of Use, the modification, and agreement to abide and be bound by the Terms of Use, as amended.', id: 'terms', label: 'Modification of Terms of Use' },
 ];
-
-/**
- * Split class models into an array or with dependencies
- * will be in an array after the array it depends on
- * @param {Object.<string,ClassModel>} schema mapping of names to class models
- */
-const splitSchemaClassLevels = (schema) => {
-    const ranks = {};
-    const queue = Object.values(schema);
-
-    while (queue.length > 0) {
-        const curr = queue.shift();
-        let dependencies = Array.from(curr.inherits || []);
-
-        for (const prop of Object.values(curr.properties)) {
-            if (prop.linkedClass) {
-                dependencies.push(prop.linkedClass.name);
-            }
-        }
-        dependencies = dependencies.filter((name) => schema[name] !== undefined);
-
-        if (dependencies.length > 0) {
-            if (dependencies.some((name) => ranks[name] === undefined)) {
-                queue.push(curr);
-            } else {
-                ranks[curr.name] = Math.max(...Array.from(dependencies, (name) => ranks[name])) + 1;
-            }
-        } else {
-            ranks[curr.name] = 0;
-        }
-    }
-    const split = [];
-
-    for (const [clsName, rank] of Object.entries(ranks)) {
-        if (split[rank] === undefined) {
-            split[rank] = [];
-        }
-        split[rank].push(schema[clsName]);
-    }
-    return split;
-};
 
 /**
  * Uses a table to track the last version of the schema for this db
@@ -119,7 +77,7 @@ const generateDefaultGroups = () => {
         admin: {}, manager: {}, readonly: {}, regular: {},
     };
 
-    for (const model of Object.values(SCHEMA_DEFN)) {
+    for (const model of Object.values(schema.models)) {
         // The permissions for operations against a class should be the intersection of the
         // exposed routes and the group type
         const { name, permissions } = model;
@@ -145,23 +103,23 @@ const createSchema = async (db) => {
     await createSchemaHistory(db);
     // create the permissions class
     logger.log('info', 'create the Permissions class');
-    await ClassModel.create(SCHEMA_DEFN.Permissions, db); // (name, extends, clusters, abstract)
+    await ClassModel.create(schema.models.Permissions, db); // (name, extends, clusters, abstract)
     // create the user class
     logger.log('info', 'create the UserGroup class');
-    await ClassModel.create(SCHEMA_DEFN.UserGroup, db, { indices: false, properties: false });
+    await ClassModel.create(schema.models.UserGroup, db, { indices: false, properties: false });
     logger.log('info', 'create the User class');
-    await ClassModel.create(SCHEMA_DEFN.User, db);
+    await ClassModel.create(schema.models.User, db);
     logger.log('info', 'Add properties to the UserGroup class');
-    await ClassModel.create(SCHEMA_DEFN.UserGroup, db, { indices: true, properties: true });
+    await ClassModel.create(schema.models.UserGroup, db, { indices: true, properties: true });
     // modify the existing vertex and edge classes to add the minimum required attributes for tracking etc
     const V = await db.class.get('V');
     await Promise.all(Array.from(
-        Object.values(SCHEMA_DEFN.V._properties).filter((p) => !p.name.startsWith('@')),
+        Object.values(schema.models.V._properties).filter((p) => !p.name.startsWith('@')),
         async (prop) => Property.create(prop, V),
     ));
     const E = await db.class.get('E');
     await Promise.all(Array.from(
-        Object.values(SCHEMA_DEFN.E._properties).filter((p) => !p.name.startsWith('@')),
+        Object.values(schema.models.E._properties).filter((p) => !p.name.startsWith('@')),
         async (prop) => Property.create(prop, E),
     ));
 
@@ -174,13 +132,12 @@ const createSchema = async (db) => {
     })));
     logger.log('info', 'defined schema for the major base classes');
     // create the other schema classes
-    const classesByLevel = splitSchemaClassLevels(
-        _.omit(SCHEMA_DEFN, ['Permissions', 'User', 'UserGroup', 'V', 'E']),
-    );
+    const classesByLevel = schema.splitClassLevels();
 
     for (const classList of classesByLevel) {
-        logger.log('info', `creating the classes: ${Array.from(classList, (cls) => cls.name).join(', ')}`);
-        await Promise.all(Array.from(classList, async (cls) => ClassModel.create(cls, db))); // eslint-disable-line no-await-in-loop
+        const toCreate = classList.filter((model) => !['Permissions', 'User', 'UserGroup', 'V', 'E'].includes(model.name));
+        logger.log('info', `creating the classes: ${Array.from(toCreate, (cls) => cls.name).join(', ')}`);
+        await Promise.all(Array.from(toCreate, async (cls) => ClassModel.create(cls, db))); // eslint-disable-line no-await-in-loop
     }
 
     // create the default user groups
@@ -188,12 +145,12 @@ const createSchema = async (db) => {
 
     logger.log('info', 'creating the default user groups');
     const defaultGroups = userGroups
-        .map((rec) => SCHEMA_DEFN.UserGroup.formatRecord(rec, { addDefaults: true }));
+        .map((rec) => schema.models.UserGroup.formatRecord(rec, { addDefaults: true }));
 
     await Promise.all(Array.from(defaultGroups, async (x) => db.insert().into('UserGroup').set(x).one()));
 
     logger.info('creating the default user agreement');
-    await db.insert().into(SCHEMA_DEFN.LicenseAgreement.name).set({
+    await db.insert().into(schema.models.LicenseAgreement.name).set({
         content: DEFAULT_LICENSE_CONTENT,
         enactedAt: timeStampNow(),
     }).one();
@@ -228,7 +185,7 @@ const loadSchema = async (db) => {
         if (/^(O[A-Z]|_)/.exec(cls.name)) { // orientdb builtin classes
             continue;
         }
-        const model = SCHEMA_DEFN[cls.name];
+        const model = schema.models[cls.name];
 
         if (model === undefined) {
             throw new Error(`The class loaded from the database (${model.name}) is not defined in the SCHEMA_DEFN`);
@@ -236,28 +193,26 @@ const loadSchema = async (db) => {
         ClassModel.compareToDbClass(model, cls); // check that the DB matches the SCHEMA_DEFN
 
         if (cls.superClass && !model.inherits.includes(cls.superClass)) {
-            throw new Error(`The class ${model.name} inherits according to the database (${cls.superClass}) does not match those defined by the schema definition: ${SCHEMA_DEFN[model.name].inherits}`);
+            throw new Error(`The class ${model.name} inherits according to the database (${cls.superClass}) does not match those defined by the schema definition: ${schema.models[model.name].inherits}`);
         }
     }
 
-    for (const cls of Object.values(SCHEMA_DEFN)) {
+    for (const cls of Object.values(schema.models)) {
         if (cls.isAbstract) {
             continue;
         }
         logger.log('verbose', `loaded class: ${cls.name} [${cls.inherits}]`);
     }
     logger.log('verbose', 'linking models');
-    db.schema = SCHEMA_DEFN;
+    db.schema = schema.models;
     // set the default record group
     logger.log('info', 'schema loading complete');
-    return SCHEMA_DEFN;
 };
 
 module.exports = {
     DEFAULT_LICENSE_CONTENT,
-    SCHEMA_DEFN,
     createSchema,
     generateDefaultGroups,
     loadSchema,
-    splitSchemaClassLevels,
+
 };

--- a/src/routes/eula.js
+++ b/src/routes/eula.js
@@ -1,7 +1,7 @@
 const HTTP_STATUS = require('http-status-codes');
 const {
     util: { timeStampNow },
-    schema: { schema: SCHEMA_DEFN },
+    schema,
     constants: { PERMISSIONS },
 } = require('@bcgsc-pori/graphkb-schema');
 
@@ -10,7 +10,7 @@ const { RecordNotFoundError, PermissionError } = require('../repo/error');
 const { checkUserAccessFor } = require('../middleware/auth');
 
 const getCurrentLicense = async (db) => db.query(
-    `SELECT * FROM ${SCHEMA_DEFN.LicenseAgreement.name} ORDER BY enactedAt DESC LIMIT 1`,
+    `SELECT * FROM ${schema.models.LicenseAgreement.name} ORDER BY enactedAt DESC LIMIT 1`,
 ).one();
 
 /**
@@ -77,7 +77,7 @@ const addEulaRoutes = (app) => {
             const { body: content, user } = req;
 
             // check for the required access
-            if (!checkUserAccessFor(user, SCHEMA_DEFN.LicenseAgreement.name, PERMISSIONS.CREATE)) {
+            if (!checkUserAccessFor(user, schema.models.LicenseAgreement.name, PERMISSIONS.CREATE)) {
                 return next(new PermissionError('Insufficient permissions to upload a license agreement'));
             }
             let session;
@@ -89,7 +89,7 @@ const addEulaRoutes = (app) => {
             }
 
             try {
-                const result = await session.insert().into(SCHEMA_DEFN.LicenseAgreement.name).set({
+                const result = await session.insert().into(schema.models.LicenseAgreement.name).set({
                     content,
                     enactedAt: timeStampNow(),
                 }).one();

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -2,7 +2,7 @@ const HTTP_STATUS = require('http-status-codes');
 const jc = require('json-cycle');
 
 const { error: { AttributeError }, schema: { schema }, schema: schemaDefn } = require('@bcgsc-pori/graphkb-schema');
-const { variant: { parse: variantParser }, error: { ParsingError } } = require('@bcgsc-pori/graphkb-parser');
+const { parseVariant, ParsingError } = require('@bcgsc-pori/graphkb-parser');
 
 const openapi = require('./openapi');
 const resource = require('./resource');
@@ -61,7 +61,7 @@ const addParserRoute = (app) => {
         }
 
         try {
-            const parsed = variantParser(content, requireFeatures);
+            const parsed = parseVariant(content, requireFeatures);
             return res.status(HTTP_STATUS.OK).json({ result: parsed });
         } catch (err) {
             if (err instanceof ParsingError) {


### PR DESCRIPTION
Improvements
- Use schema 3.16.0 (use schema.models instead of schema.schema for readability)
- Use parser 2.0.0

Note: for now set audit to only break on critical errors b/c there is an unresolvable high audit error. I am hoping this will be fixable properly by the time we are ready to release

Converting the API to typescript itself will be a separate PR