### PR TITLE
Add variant parser pkg version to version endpoint

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ const {
     addStatsRoute, addParserRoute, addQueryRoute, addErrorRoute,
 } = require('./routes');
 const config = require('./config');
+const packageLockJson = require('../package-lock.json');
 
 // https://github.com/nodejs/node-v0.x-archive/issues/9075
 http.globalAgent.keepAlive = true;
@@ -161,6 +162,7 @@ class AppServer {
             res.status(HTTP_STATUS.OK).json({
                 api: process.env.npm_package_version,
                 db: GKB_DB_NAME,
+                parser: packageLockJson.packages['node_modules/@bcgsc-pori/graphkb-parser'].version,
                 schema: getLoadVersion().version,
             });
         });

--- a/src/routes/openapi/routes.js
+++ b/src/routes/openapi/routes.js
@@ -137,6 +137,7 @@ const GET_VERSION = {
                         properties: {
                             api: { description: 'Version of the API', example: '0.6.3', type: 'string' },
                             db: { description: 'Name of the database the API is connected to', example: 'kbapi_v0.6.3', type: 'string' },
+                            parser: { description: 'Version of the variant parser package', example: '2.0.0', type: 'string' },
                             schema: { description: 'Version of the schema package used to build the database', example: '1.2.1', type: 'string' },
                         },
                         type: 'object',


### PR DESCRIPTION
This PR relate to : https://www.bcgsc.ca/jira/browse/KBDEV-897

The checks on this PR should be resolved by merging with release/v3.13.5 after PR https://github.com/bcgsc/pori_graphkb_api/pull/40 since it is the same commitizen and cz-conventional-changelog dependencies issue.