### PR TITLE
Test with orientdb3.2

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         node: [12, 14, 16]
-        orientdb: ['3.0', '3.1']
+        orientdb: ['3.0', '3.1', '3.2']
     name: orientdb-${{ matrix.orientdb }} node-${{ matrix.node }}
     services:
       orientdb:

--- a/src/repo/index.js
+++ b/src/repo/index.js
@@ -31,11 +31,11 @@ const createDB = async (server, {
 
     try {
         await db.command('alter database custom standardElementConstraints=false');
-        let admin_user_exists = await db.query("select status from OUser where name = 'admin';").all();
-        if (admin_user_exists.length === 0) {
+        const adminUserExists = await db.query('select status from OUser where name = \'admin\';').all();
+
+        if (adminUserExists.length === 0) {
             await db.command('create user admin identified by admin role admin;');
         }
-        //admin_user_exists = await db.command("select status from OUser where name = 'admin';").get();
 
         logger.log('verbose', 'create the schema');
         await createSchema(db);

--- a/src/repo/index.js
+++ b/src/repo/index.js
@@ -22,6 +22,7 @@ const createDB = async (server, {
         password: GKB_DBS_PASS,
         username: GKB_DBS_USER,
     });
+
     const db = await server.session({
         name: GKB_DB_NAME,
         password: GKB_DBS_PASS,
@@ -29,6 +30,7 @@ const createDB = async (server, {
     });
 
     try {
+        await db.command('create user admin identified by admin role admin;');
         await db.command('alter database custom standardElementConstraints=false');
         logger.log('verbose', 'create the schema');
         await createSchema(db);

--- a/src/repo/index.js
+++ b/src/repo/index.js
@@ -30,8 +30,13 @@ const createDB = async (server, {
     });
 
     try {
-        await db.command('create user admin identified by admin role admin;');
         await db.command('alter database custom standardElementConstraints=false');
+        let admin_user_exists = await db.query("select status from OUser where name = 'admin';").all();
+        if (admin_user_exists.length === 0) {
+            await db.command('create user admin identified by admin role admin;');
+        }
+        //admin_user_exists = await db.command("select status from OUser where name = 'admin';").get();
+
         logger.log('verbose', 'create the schema');
         await createSchema(db);
     } catch (err) {


### PR DESCRIPTION
- updates npm-test github workflow to run on orientdb3.2
- updates db creation to create admin user if one does not exist (to handle change in 3.2 from 3.1 and 3.0, where admin user is no longer automatically created - https://orientdb.org/docs/3.2.x/release/3.2/Upgrading-to-OrientDB-3.2.html) 