### PR TITLE
Add displayName in EvidenceLevel keyword search

### DIFF
--- a/src/repo/query_builder/fixed.js
+++ b/src/repo/query_builder/fixed.js
@@ -323,7 +323,8 @@ const singleKeywordSearch = ({
         FROM ${targetQuery || model.name}
         WHERE name ${operator} :${param}
             OR sourceId ${operator} :${param}
-            OR source.name ${operator} :${param}`;
+            OR source.name ${operator} :${param}
+            OR displayName.toLowerCase() ${operator} :${param}`;
     } if (schemaDefn.inheritsFrom(model.name, 'Ontology') || model.name === 'Ontology' || model.name === 'Evidence') {
         return `SELECT *
         FROM ${targetQuery || model.name}


### PR DESCRIPTION
Problem wasn't the "special character" after all, but the fact that the displayName wasn't part of the keyword search for EvidenceLevel specifically.

```
SELECT @class, @rid, name, displayName, source.name FROM EvidenceLevel WHERE name CONTAINSTEXT 'ipr-' OR sourceId CONTAINSTEXT 'ipr-' OR source.name CONTAINSTEXT 'ipr-' OR displayName.toLowerCase() CONTAINSTEXT 'ipr-' 

+----+-------+-------------+----------+-----+----+-----------+-----------+
|#   |@RID   |@CLASS       |deprecated|alias|name|displayName|source.name|
+----+-------+-------------+----------+-----+----+-----------+-----------+
|0   |#105:19|EvidenceLevel|false     |false|b   |IPR-B      |ipr        |
|1   |#106:32|EvidenceLevel|false     |false|c   |IPR-C      |ipr        |
|2   |#107:15|EvidenceLevel|false     |false|d   |IPR-D      |ipr        |
|3   |#108:30|EvidenceLevel|false     |false|a   |IPR-A      |ipr        |
|4   |#108:31|EvidenceLevel|false     |false|e   |IPR-E      |ipr        |
+----+-------+-------------+----------+-----+----+-----------+-----------+

```