### PR TITLE
Bugfix/KBDEV-1143: Ensembl loader not show displayName correctly 

### DIFF
--- a/src/repo/commands/select.js
+++ b/src/repo/commands/select.js
@@ -244,6 +244,8 @@ const fetchDisplayName = async (db, modelName, content) => {
             subject: recordsById[recId(content.subject)],
         };
         return sentenceTemplates.chooseDefaultTemplate(templateContent);
+    } if (model.name === 'Feature' && content.displayName) {
+        return content.displayName;
     }
     return content.name;
 };


### PR DESCRIPTION
When running the refseq and ensembl loader, the displayName is same as the name column, which should be [sourceId.toUpperCase()].[sourceIdVersion]. 
Figured out it is because the fetchDisplayName function returns the content.name by default. 
Tested with some refseq and ensembl records:
```
orientdb {db=test_shirley5}> select sourceId, displayName, name from Feature where source.displayName="RefSeq" and deletedAt is null limit 5
+----+------------+------------+------------+
|#   |sourceId    |displayName |name        |
+----+------------+------------+------------+
|0   |nm_001006118|NM_001006118|nm_001006118|
|1   |np_055391   |NP_055391   |np_055391   |
|2   |np_620310   |NP_620310   |np_620310   |
|3   |np_620311   |NP_620311   |np_620311   |
|4   |np_001185747|NP_001185747|np_001185747|
+----+------------+------------+------------+

orientdb {db=test_shirley5}> select displayName, sourceId, sourceIdVersion, name from Feature where source.displayName="Ensembl" and deletedAt is null order by createdAt desc limit 5
+----+---------------+-----------------+---------------+---------------+
|#   |sourceId       |displayName      |sourceIdVersion|name           |
+----+---------------+-----------------+---------------+---------------+
|0   |enst00000361789|ENST00000361789  |               |enst00000361789|
|1   |enst00000361789|ENST00000361789.2|2              |enst00000361789|
|2   |ensg00000198727|ENSG00000198727  |               |ensg00000198727|
|3   |ensg00000198727|ENSG00000198727.2|2              |ensg00000198727|
|4   |enst00000361681|ENST00000361681  |               |enst00000361681|
+----+---------------+-----------------+---------------+---------------+
```
