### PR TITLE
Feature/kbdev 1505 upload hgvs route

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ const { connectDB } = require('./repo');
 const { getLoadVersion } = require('./repo/migrate/version');
 const { addExtensionRoutes } = require('./extensions');
 const { addSubgraphRoutes } = require('./routes/subgraphs');
+const { addHgvsUploadRoute } = require('./routes/upload');
 const { generateSwaggerSpec, registerSpecEndpoints } = require('./routes/openapi');
 const { addResourceRoutes } = require('./routes/resource');
 const { addPostToken } = require('./routes/auth');
@@ -195,6 +196,7 @@ class AppServer {
         }
         addExtensionRoutes(this);
         addSubgraphRoutes(this);
+        addHgvsUploadRoute(this);
 
         // catch any other errors
         addErrorRoute(this);

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -103,8 +103,30 @@ const checkSubgraphPermissions = async (req, res, next) => {
     return next();
 };
 
+/**
+ * Check that the user has permissions for the upload classes. Note that to do this, models and user
+ * need to already be assigned to the request.
+ *
+ * @param {GraphKBRequest} req
+ * @param {ClassDefinition} req.models an array of models for this request
+ *
+ */
+const checkHgvsUploadPermissions = async (req, res, next) => {
+    const { models, user } = req;
+
+    for (let i = 0; i < models.length; i++) {
+        if (!checkUserAccessFor(user, models[i], PERMISSIONS.CREATE)) {
+            return res.status(HTTP_STATUS.FORBIDDEN).json(new PermissionError(
+                `The user ${user.name} does not have sufficient permissions on classes ${models[i]}`,
+            ));
+        }
+    }
+    return next();
+};
+
 module.exports = {
     checkClassPermissions,
+    checkHgvsUploadPermissions,
     checkSubgraphPermissions,
     checkToken,
     checkUserAccessFor,

--- a/src/repo/upload/positionalvariant.js
+++ b/src/repo/upload/positionalvariant.js
@@ -6,8 +6,8 @@ const { util: { looksLikeRID } } = require('@bcgsc-pori/graphkb-schema');
 const { create, select } = require('../commands');
 const { parse } = require('../query_builder/index');
 const {
+    NoRecordFoundError,
     RecordConflictError,
-    NotImplementedError,
     ValidationError,
 } = require('../error');
 
@@ -50,8 +50,8 @@ const getTypeRID = async (session, type) => {
     );
 
     if (result.length === 0) {
-        throw new NotImplementedError({
-            message: `Vocabulary ${type} not implemented as DB record. Vocabulary ontology must be uploaded first`,
+        throw new NoRecordFoundError({
+            message: `Vocabulary record ${type} dosen't exists. Vocabulary ontology must be uploaded first`,
         });
     }
     return String(result[0]['@rid']);
@@ -82,8 +82,8 @@ const getReferenceRID = async (session, ref, { preferedRefSrcName } = {}) => {
 
     if (result.length === 0) {
         // TODO: Add support for new Feature upload
-        throw new NotImplementedError({
-            message: `Feature ${referenceDisplayName} not implemented as DB record`,
+        throw new NoRecordFoundError({
+            message: `Feature record ${referenceDisplayName} dosen't exists`,
         });
     }
     if (result.length > 1) {

--- a/src/repo/upload/positionalvariant.js
+++ b/src/repo/upload/positionalvariant.js
@@ -1,0 +1,245 @@
+/* eslint-disable no-return-await */
+const _ = require('lodash');
+const { parseVariant, jsonifyVariant } = require('@bcgsc-pori/graphkb-parser');
+const { util: { looksLikeRID } } = require('@bcgsc-pori/graphkb-schema');
+
+const { create, select } = require('../commands');
+const { parse } = require('../query_builder/index');
+const {
+    RecordConflictError,
+    NotImplementedError,
+    ValidationError,
+} = require('../error');
+
+/**
+ * Given a reference displayName from user input, format and
+ * make sure any chromosomes is represented in a GraphKB-compatible way
+ *
+ * @param {string} ref the reference displayName
+ * @returns {string} the formatted displayName
+ */
+const formatReferenceDisplayName = (ref) => {
+    let match;
+
+    // Chromosome reference handling
+    if ((match = ref.match(/^CHR\d{1,2}$/i))) return ref.toLowerCase();
+    if ((match = ref.match(/^\d{1,2}$/i))) return `chr${ref}`;
+    if ((match = ref.match(/^(MT|X|Y)$/i))) return ref.toLowerCase();
+    if ((match = ref.match(/^CHR(MT|X|Y)$/i))) return match[1].toLowerCase();
+    if ((match = ref.match(/^NC_0*(\d+)(?:\.\d+)?$/i))) return `chr${match[1]}`; // RefSeq NC_
+
+    // default, all caps for all non-chromosome references
+    return ref.toUpperCase();
+};
+
+/**
+ * Given a Vocabulary name as variant's type, returns its RID
+ *
+ * @param {Object} session the DB session object
+ * @param {string} opt.type the variant type name
+ * @returns {string} the strignify record's RID
+ */
+const getType = async (session, type) => {
+    const result = await select(
+        session,
+        parse({
+            filters: { name: type.toLowerCase() },
+            returnProperties: ['@rid'],
+            target: 'Vocabulary',
+        }),
+    );
+
+    if (result.length === 0) {
+        throw new NotImplementedError({
+            message: `Vocabulary ${type} not implemented as DB record. Vocabulary ontology must be uploaded first`,
+        });
+    }
+    return String(result[0]['@rid']);
+};
+
+/**
+ * Given a Feature displayName (reference), returns its RID
+ *
+ * @param {Object} session the DB session object
+ * @param {string} reference the reference displayName
+ * @param {string} [opt.preferedRefSrcName] the name of the prefered reference source
+ * @returns {string} the strignify record's RID
+ */
+const getReference = async (session, ref, { preferedRefSrcName } = {}) => {
+    // Chromosome support
+    const referenceDisplayName = formatReferenceDisplayName(ref);
+
+    // Feature
+    // Lookup on displayName for easier version support
+    const result = await select(
+        session,
+        parse({
+            filters: { displayName: referenceDisplayName },
+            returnProperties: ['@rid', 'source.name'],
+            target: 'Feature',
+        }),
+    );
+
+    if (result.length === 0) {
+        // TODO: Add support for new Feature upload
+        throw new NotImplementedError({
+            message: `Feature ${referenceDisplayName} not implemented as DB record`,
+        });
+    }
+    if (result.length > 1) {
+        // pick the one from prefered source
+        if (preferedRefSrcName) {
+            for (const r of result) {
+                if (r.source.name === preferedRefSrcName) {
+                    return String(r['@rid']);
+                }
+            }
+        }
+    }
+    // defaults to 1st one
+    return String(result[0]['@rid']);
+};
+
+/**
+ * Extract and format content from an HGVS-like variant notation.
+ * Type and references are replaced by their RIDs.
+ *
+ * @param {Object} session the DB session object
+ * @param {string} notation the variant notation
+ * @param {string} [opt.preferedRefSrcName] the name of the prefered reference source
+ * @returns {object} the upload content of a PositionalVariant
+ */
+const getContent = async (session, notation, { preferedRefSrcName } = {}) => {
+    // Validation
+    if (typeof notation !== 'string' || notation.trim().length === 0) {
+        throw new ValidationError(
+            { message: 'notation is required and must be a non-empty string' },
+        );
+    }
+
+    // Notation parsing
+    const content = jsonifyVariant(
+        parseVariant(notation),
+    );
+
+    // Replacing variant type by its RID
+    content.type = await getType(session, content.type);
+
+    // Replacing variant references by their RIDs
+    content.reference1 = await getReference(
+        session,
+        content.reference1,
+        { preferedRefSrcName },
+    );
+
+    if (content.reference2) {
+        content.reference2 = await getReference(
+            session,
+            content.reference2,
+            { preferedRefSrcName },
+        );
+    }
+
+    return content;
+};
+
+/**
+ * Given the upload content for a new PositionalVariant,
+ * get the filters object for a select command
+ *
+ * @param {Object} content initially used to attempt creating a new PositionalVariant
+ * @returns {object} the filters object
+ */
+const positionalVariantQueryFilters = (content) => ({
+    AND: [
+        'break1Repr',
+        'break2Repr',
+        'reference1',
+        'reference2',
+        'refSeq',
+        'truncation',
+        'type',
+        'untemplatedSeq',
+        'untemplatedSeqSize',
+    ]
+        .filter((prop) => prop in content)
+        .map((prop) => ({ [prop]: content[prop] })),
+});
+
+/**
+ * Upload a new PositionalVariant based on content
+ * Will attempt to replace type and references by RIDs if needed
+ * Existing record can optionally (default) be fetched and returned
+ *
+ * @param {Object} session the DB session object
+ * @param {Object} user the user object
+ * @param {Object} content the content's payload
+ * @param {boolean} [opt.existsOk=true] to return existing record
+ * @param {string} [opt.preferedRefSrcName] the name of the prefered reference source
+ * @returns {[Record<string, any>, string]} Array containing:
+ *   - first element: the record object
+ *   - second element: the status name
+ */
+const uploadPositionalVariant = async (session, user, content, {
+    existsOk = true,
+    preferedRefSrcName,
+} = {}) => {
+    const payload = _.cloneDeep(content);
+
+    // Make sure type is an RID
+    if (!looksLikeRID(payload.type, true)) {
+        payload.type = await getType(session, payload.type);
+    }
+    // Make sure references are RIDs
+    if (!looksLikeRID(payload.reference1, true)) {
+        payload.reference1 = await getReference(
+            session,
+            payload.reference1,
+            { preferedRefSrcName },
+        );
+    }
+    if (payload.reference2 && !looksLikeRID(payload.reference2, true)) {
+        payload.reference2 = await getReference(
+            session,
+            payload.reference2,
+            { preferedRefSrcName },
+        );
+    }
+
+    // Upload
+    try {
+        return [
+            await create(session, {
+                content: payload,
+                modelName: 'PositionalVariant',
+                user,
+            }),
+            'CREATED',
+        ];
+    } catch (err) {
+        // Return existing record
+        if (err instanceof RecordConflictError && existsOk) {
+            return [
+                ...await select(
+                    session,
+                    parse({
+                        filters: positionalVariantQueryFilters(payload),
+                        target: 'PositionalVariant',
+                    }),
+                    { user },
+                ),
+                'OK',
+            ];
+        }
+        throw err;
+    }
+};
+
+module.exports = {
+    formatReferenceDisplayName,
+    getContent,
+    getReference,
+    getType,
+    positionalVariantQueryFilters,
+    uploadPositionalVariant,
+};

--- a/src/repo/upload/positionalvariant.js
+++ b/src/repo/upload/positionalvariant.js
@@ -37,7 +37,7 @@ const formatReferenceDisplayName = (ref) => {
  *
  * @param {Object} session the DB session object
  * @param {string} opt.type the variant type name
- * @returns {string} the strignify record's RID
+ * @returns {string} the strignified record's RID
  */
 const getTypeRID = async (session, type) => {
     const result = await select(

--- a/src/repo/upload/positionalvariant.js
+++ b/src/repo/upload/positionalvariant.js
@@ -39,7 +39,7 @@ const formatReferenceDisplayName = (ref) => {
  * @param {string} opt.type the variant type name
  * @returns {string} the strignify record's RID
  */
-const getType = async (session, type) => {
+const getTypeRID = async (session, type) => {
     const result = await select(
         session,
         parse({
@@ -65,7 +65,7 @@ const getType = async (session, type) => {
  * @param {string} [opt.preferedRefSrcName] the name of the prefered reference source
  * @returns {string} the strignify record's RID
  */
-const getReference = async (session, ref, { preferedRefSrcName } = {}) => {
+const getReferenceRID = async (session, ref, { preferedRefSrcName } = {}) => {
     // Chromosome support
     const referenceDisplayName = formatReferenceDisplayName(ref);
 
@@ -123,17 +123,17 @@ const getContent = async (session, notation, { preferedRefSrcName } = {}) => {
     );
 
     // Replacing variant type by its RID
-    content.type = await getType(session, content.type);
+    content.type = await getTypeRID(session, content.type);
 
     // Replacing variant references by their RIDs
-    content.reference1 = await getReference(
+    content.reference1 = await getReferenceRID(
         session,
         content.reference1,
         { preferedRefSrcName },
     );
 
     if (content.reference2) {
-        content.reference2 = await getReference(
+        content.reference2 = await getReferenceRID(
             session,
             content.reference2,
             { preferedRefSrcName },
@@ -188,18 +188,18 @@ const uploadPositionalVariant = async (session, user, content, {
 
     // Make sure type is an RID
     if (!looksLikeRID(payload.type, true)) {
-        payload.type = await getType(session, payload.type);
+        payload.type = await getTypeRID(session, payload.type);
     }
     // Make sure references are RIDs
     if (!looksLikeRID(payload.reference1, true)) {
-        payload.reference1 = await getReference(
+        payload.reference1 = await getReferenceRID(
             session,
             payload.reference1,
             { preferedRefSrcName },
         );
     }
     if (payload.reference2 && !looksLikeRID(payload.reference2, true)) {
-        payload.reference2 = await getReference(
+        payload.reference2 = await getReferenceRID(
             session,
             payload.reference2,
             { preferedRefSrcName },
@@ -238,8 +238,8 @@ const uploadPositionalVariant = async (session, user, content, {
 module.exports = {
     formatReferenceDisplayName,
     getContent,
-    getReference,
-    getType,
+    getReferenceRID,
+    getTypeRID,
     positionalVariantQueryFilters,
     uploadPositionalVariant,
 };

--- a/src/routes/openapi/index.js
+++ b/src/routes/openapi/index.js
@@ -12,16 +12,17 @@ const HTTP_STATUS = require('http-status-codes');
 const swaggerUi = require('swagger-ui-express');
 
 const {
-    POST_TOKEN,
-    POST_PARSE,
-    GET_SCHEMA,
-    GET_VERSION,
-    QUERY,
-    GET_STATS,
-    POST_SIGN_LICENSE,
-    POST_LICENSE,
     GET_LICENSE,
+    GET_SCHEMA,
+    GET_STATS,
+    GET_VERSION,
+    POST_LICENSE,
+    POST_PARSE,
+    POST_SIGN_LICENSE,
+    POST_TOKEN,
+    QUERY,
     SUBGRAPHS,
+    UPLOAD_HGVS,
 } = require('./routes');
 const responses = require('./responses');
 const schemas = require('./schemas');
@@ -72,8 +73,7 @@ const STUB = {
     paths: {
         '/license': { get: GET_LICENSE, post: POST_LICENSE },
         '/license/sign': { post: POST_SIGN_LICENSE },
-        '/parse': { post: POST_PARSE },
-        '/query': { post: QUERY },
+        // Metadata
         '/schema': { get: GET_SCHEMA },
         '/spec': {
             get: {
@@ -104,9 +104,13 @@ const STUB = {
             },
         },
         '/stats': { get: GET_STATS },
+        '/version': { get: GET_VERSION },
+        // General
+        '/parse': { post: POST_PARSE },
+        '/upload/hgvs': { post: UPLOAD_HGVS },
+        '/query': { post: QUERY },
         '/subgraphs/{ontology}': { post: SUBGRAPHS },
         '/token': { post: POST_TOKEN },
-        '/version': { get: GET_VERSION },
     },
     tags: [{
         description: 'routes dealing with app metadata', name: 'Metadata',

--- a/src/routes/openapi/routes.js
+++ b/src/routes/openapi/routes.js
@@ -498,7 +498,7 @@ const UPLOAD_HGVS = {
                         },
                     },
                     '3 - Pick a prefered ontology': {
-                        description: 'When more than one Feature record match the reference, pick the one from a prefered ontology source',
+                        description: 'When more than one Feature record matches the reference, pick the one from a prefered ontology source',
                         value: {
                             notation: 'TP53:p.V10del',
                             preferedRefSrcName: 'entrez gene',

--- a/src/routes/openapi/routes.js
+++ b/src/routes/openapi/routes.js
@@ -535,7 +535,7 @@ const UPLOAD_HGVS = {
                     },
                 },
             },
-            description: 'A new PositionalVariant record has been created',
+            description: 'An existing PositionalVariant record has been fetched',
         },
         201: {
             content: {
@@ -551,7 +551,7 @@ const UPLOAD_HGVS = {
                     },
                 },
             },
-            description: 'An existing PositionalVariant record has been fetched',
+            description: 'A new PositionalVariant record has been created',
         },
         409: { $ref: '#/components/responses/RecordConflictError' },
     },

--- a/src/routes/openapi/routes.js
+++ b/src/routes/openapi/routes.js
@@ -477,6 +477,88 @@ const POST_LICENSE = {
     tags: ['Permissions'],
 };
 
+const UPLOAD_HGVS = {
+    requestBody: {
+        content: {
+            'application/json': {
+                examples: {
+                    '1 - Parse and upload': {
+                        description: 'Parsing an HGVS-like variant notation, with RID substitutions, and upload as new PositionalVariant',
+                        value: {
+                            notation: 'TP53:p.V10del',
+
+                        },
+                    },
+                    '2 - Parse only': {
+                        description: 'Parsing an HGVS-like variant notation, with RID substitutions, without actual upload',
+                        value: {
+                            notation: 'TP53:p.V10del',
+                            upload: false,
+
+                        },
+                    },
+                    '3 - Pick a prefered ontology': {
+                        description: 'When more than one Feature record match the reference, pick the one from a prefered ontology source',
+                        value: {
+                            notation: 'TP53:p.V10del',
+                            preferedRefSrcName: 'entrez gene',
+
+                        },
+                    },
+                    '4 - Return error if already exists': {
+                        description: '',
+                        value: {
+                            notation: 'TP53:p.V10del',
+                            existsOk: false,
+                        },
+                    },
+                },
+                schema: {
+                    $ref: '#/components/schemas/UploadHgvsQuery',
+                },
+            },
+        },
+        required: true,
+    },
+    responses: {
+        200: {
+            content: {
+                'application/json': {
+                    schema: {
+                        properties: {
+                            result: {
+                                type: 'object',
+                            },
+                        },
+                        required: ['result'],
+                        type: 'object',
+                    },
+                },
+            },
+            description: 'A new PositionalVariant record has been created',
+        },
+        201: {
+            content: {
+                'application/json': {
+                    schema: {
+                        properties: {
+                            result: {
+                                type: 'object',
+                            },
+                        },
+                        required: ['result'],
+                        type: 'object',
+                    },
+                },
+            },
+            description: 'An existing PositionalVariant record has been fetched',
+        },
+        409: { $ref: '#/components/responses/RecordConflictError' },
+    },
+    summary: 'Parse and upload a variant string as a PositionalVariant record',
+    tags: ['General'],
+};
+
 module.exports = {
     GET_LICENSE,
     GET_SCHEMA,
@@ -488,4 +570,5 @@ module.exports = {
     POST_TOKEN,
     QUERY,
     SUBGRAPHS,
+    UPLOAD_HGVS,
 };

--- a/src/routes/openapi/schemas.js
+++ b/src/routes/openapi/schemas.js
@@ -501,6 +501,36 @@ const VSubgraph = {
     type: 'object',
 };
 
+const UploadHgvsQuery = {
+    description: 'The UploadHgvsQuery object as the body payload of a upload/hgvs query',
+    properties: {
+        existsOk: {
+            default: true,
+            description: 'When conflict with existing record, returns that record instead of throwing an error',
+            type: 'boolean',
+        },
+        notation: {
+            description: 'HGVS-like variant notation',
+            type: 'string',
+        },
+        preferedRefSrcName: {
+            description: 'Source name of the prefered ontology for references (Feature)',
+            enum: [
+                'entrez gene',
+                'hgnc',
+            ],
+            type: 'string',
+        },
+        upload: {
+            default: true,
+            description: 'upload the parsed notation as new PositionalVariant record',
+            type: 'boolean',
+        },
+    },
+    required: ['notation'],
+    type: 'object',
+};
+
 const Clause = {
     oneOf: [
         {
@@ -603,4 +633,5 @@ module.exports = {
         description: 'The number of records to skip. Used in combination with limit for paginating queries.', min: 0, nullable: true, type: 'integer',
     },
     source,
+    UploadHgvsQuery,
 };

--- a/src/routes/upload.js
+++ b/src/routes/upload.js
@@ -93,6 +93,7 @@ const addHgvsUploadRoute = (app) => {
             try {
                 session = await app.pool.acquire();
             } catch (err) {
+                logger.log('debug', err);
                 return next(err);
             }
 
@@ -104,12 +105,14 @@ const addHgvsUploadRoute = (app) => {
                 content = await getContent(session, notation, opt);
             } catch (err) {
                 session.close();
+                logger.log('debug', err);
                 return next(err);
             }
 
             // Return content as json; no upload.
             // Useful if properties need to be reviewed or added (e.g. germline, assembly, etc.)
             if (body.upload === false) {
+                session.close();
                 return res.status(HTTP_STATUS.OK).json(jc.decycle({ result: content }));
             }
 

--- a/src/routes/upload.js
+++ b/src/routes/upload.js
@@ -17,7 +17,7 @@ const addHgvsUploadRoute = (app) => {
     const hgvsUploadRoutePattern = '/upload/hgvs';
 
     // attach models for checking class permissions
-    app.router.use(hgvsUploadRoutePattern, (req, _, next) => {
+    app.router.use(hgvsUploadRoutePattern, (req, res, next) => {
         const { body: { upload, uploadRef } } = req;
 
         req.models = [];

--- a/src/routes/upload.js
+++ b/src/routes/upload.js
@@ -1,0 +1,134 @@
+const _ = require('lodash');
+const jc = require('json-cycle');
+const HTTP_STATUS = require('http-status-codes');
+const { ValidationError } = require('@bcgsc-pori/graphkb-schema');
+
+const { checkHgvsUploadPermissions } = require('../middleware/auth');
+const { logger } = require('../repo/logging');
+const { getContent, uploadPositionalVariant } = require('../repo/upload/positionalvariant');
+
+/**
+ * Route to upload a PositionalVariant record
+ * based on an HGVS-like notation string.
+ *
+ * @param {AppServer} app the GraphKB app server
+ */
+const addHgvsUploadRoute = (app) => {
+    const hgvsUploadRoutePattern = '/upload/hgvs';
+
+    // attach models for checking class permissions
+    app.router.use(hgvsUploadRoutePattern, (req, _, next) => {
+        const { body: { upload, uploadRef } } = req;
+
+        req.models = [];
+
+        if (upload === true) {
+            req.models.push('PositionalVariant');
+        }
+        // TODO: Add support for Feature upload
+        if (uploadRef === true) {
+            req.models.push('Feature');
+        }
+        next();
+    });
+    // route-specific middleware for class permissions check
+    app.router.use(hgvsUploadRoutePattern, checkHgvsUploadPermissions);
+
+    logger.log('verbose', `NEW ROUTE [POST] ${hgvsUploadRoutePattern}`);
+    app.router.post(
+        hgvsUploadRoutePattern,
+        async (req, res, next) => {
+            const { body, query } = req;
+
+            // Validation
+            if (!_.isEmpty(query)) {
+                return next(new ValidationError(
+                    { message: 'No query parameters are allowed for this query type', params: query },
+                ));
+            }
+            if (!body) {
+                return next(new ValidationError(
+                    { message: 'request body is required' },
+                ));
+            }
+            if (!body.notation) {
+                return next(new ValidationError(
+                    { message: 'request body.notation is required. Must provide an HGVS-like variant notation' },
+                ));
+            }
+            if (body.upload && typeof body.upload !== 'boolean') {
+                return next(new ValidationError(
+                    { message: 'request body.upload must be a boolean' },
+                ));
+            }
+            if (body.existsOk && typeof body.existsOk !== 'boolean') {
+                return next(new ValidationError(
+                    { message: 'request body.existsOk must be a boolean' },
+                ));
+            }
+
+            const invalidParams = [];
+
+            // Allowed params
+            for (const prop of Object.keys(body)) {
+                if (![
+                    'notation',
+                    'upload',
+                    'existsOk',
+                    'preferedRefSrcName',
+                ].includes(prop)) {
+                    invalidParams.push(prop);
+                }
+            }
+
+            if (invalidParams.length) {
+                return next(new ValidationError({
+                    message: `Invalid parameters: ${invalidParams.join(', ')}`,
+                }));
+            }
+
+            // Session
+            let session;
+
+            try {
+                session = await app.pool.acquire();
+            } catch (err) {
+                return next(err);
+            }
+
+            // Content
+            let content;
+
+            try {
+                const { notation, ...opt } = body;
+                content = await getContent(session, notation, opt);
+            } catch (err) {
+                session.close();
+                return next(err);
+            }
+
+            // Return content as json; no upload.
+            // Useful if properties need to be reviewed or added (e.g. germline, assembly, etc.)
+            if (body.upload === false) {
+                return res.status(HTTP_STATUS.OK).json(jc.decycle({ result: content }));
+            }
+
+            // PV upload (default)
+            try {
+                const [result, status] = await uploadPositionalVariant(session, req.user, content, {
+                    existsOk: body.existsOk,
+                });
+                session.close();
+                return res.status(HTTP_STATUS[status]).json(jc.decycle({ result }));
+            } catch (err) {
+                session.close();
+                logger.log('debug', err);
+                return next(err);
+            }
+        },
+    );
+};
+
+module.exports = {
+    addHgvsUploadRoute,
+};

--- a/test/repo/upload/positionalvariant.test.js
+++ b/test/repo/upload/positionalvariant.test.js
@@ -1,0 +1,280 @@
+// Mocks
+jest.mock('../../../src/repo/commands', () => ({
+    create: jest.fn(),
+    select: jest.fn(),
+}));
+
+jest.mock('../../../src/repo/query_builder/index', () => ({
+    parse: jest.fn((query) => query),
+}));
+
+jest.mock('../../../src/repo/error', () => ({
+    NotImplementedError: class NotImplementedError extends Error {
+        constructor(obj) {
+            super(obj.message);
+            this.name = 'ValidationError';
+        }
+    },
+    RecordConflictError: class RecordConflictError extends Error {
+        constructor(obj) {
+            super(obj.message);
+            this.name = 'RecordConflictError';
+        }
+    },
+    ValidationError: class ValidationError extends Error {
+        constructor(obj) {
+            super(obj.message);
+            this.name = 'ValidationError';
+        }
+    },
+}));
+
+// Dependencies
+const { create, select } = require('../../../src/repo/commands');
+const { parse } = require('../../../src/repo/query_builder/index');
+const {
+    NotImplementedError,
+    RecordConflictError,
+    ValidationError,
+} = require('../../../src/repo/error');
+const {
+    formatReferenceDisplayName,
+    getContent,
+    getReference,
+    getType,
+    positionalVariantQueryFilters,
+    uploadPositionalVariant,
+} = require('../../../src/repo/upload/positionalvariant');
+
+// Tests
+describe('formatReferenceDisplayName', () => {
+    test.each([
+        // chromosomes
+        ['1', 'chr1'],
+        ['12', 'chr12'],
+        ['chr2', 'chr2'],
+        ['CHR23', 'chr23'],
+        ['mt', 'mt'],
+        ['X', 'x'],
+        ['chry', 'y'],
+        ['CHRY', 'y'],
+        ['NC_000012', 'chr12'],
+        ['NC_000012.3', 'chr12'],
+        // others; all caps
+        ['brca2', 'BRCA2'],
+        ['TP53', 'TP53'],
+        ['nm_12345.1', 'NM_12345.1'],
+    ])('%s -> %s', (ref, formatted) => {
+        expect(formatReferenceDisplayName(ref)).toBe(formatted);
+    });
+});
+
+describe('getType', () => {
+    const session = {};
+
+    beforeEach(() => {
+        select.mockResolvedValue([{ '@rid': '#123:45' }]);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('type is formatted to lowercase', async () => {
+        await getType(session, 'Substitution');
+        expect(parse).toHaveBeenCalledWith(expect.objectContaining({
+            filters: { name: 'substitution' },
+        }));
+    });
+
+    test('returns RID when vocabulary is found', async () => {
+        await expect(getType(session, 'substitution')).resolves.toBe('#123:45');
+    });
+
+    test('throws NotImplementedError when vocabulary is not found', async () => {
+        select.mockResolvedValue([]);
+
+        await expect(getType(session, 'unknown')).rejects.toBeInstanceOf(NotImplementedError);
+    });
+});
+
+describe('getReference', () => {
+    const session = {};
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        select.mockResolvedValue([
+            { '@rid': '#123:45', source: { name: 'hgnc' } },
+            { '@rid': '#123:46', source: { name: 'entrez gene' } },
+        ]);
+    });
+
+    test('normalizes chromosome notation before querying', async () => {
+        await getReference(session, '12');
+        expect(parse).toHaveBeenCalledWith(expect.objectContaining({
+            filters: { displayName: 'chr12' },
+        }));
+    });
+
+    test('returns first RID when there is no preferedRefSrcName provided', async () => {
+        await expect(getReference(session, 'BRCA2', {})).resolves.toBe('#123:45');
+    });
+
+    test('uses preferred source if preferedRefSrcName is provided', async () => {
+        await expect(getReference(session, 'BRCA2', { preferedRefSrcName: 'entrez gene' })).resolves.toBe('#123:46');
+    });
+
+    test('throws NotImplementedError when no feature is found', async () => {
+        select.mockResolvedValue([]);
+
+        await expect(getReference(session, 'BRCA2', {})).rejects.toBeInstanceOf(NotImplementedError);
+    });
+});
+
+describe('getContent', () => {
+    const session = {};
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        select
+            .mockResolvedValueOnce([{ '@rid': '#123:45' }]) // getType()
+            .mockResolvedValueOnce([{ '@rid': '#123:46', source: { name: 'hgnc' } }]) // getReference()
+            .mockResolvedValueOnce([{ '@rid': '#123:47', source: { name: 'hgnc' } }]); // getReference()
+    });
+
+    test('throws ValidationError when notation is empty string', async () => {
+        await expect(getContent(session, '')).rejects.toBeInstanceOf(ValidationError);
+    });
+
+    test('parses notation and replaces type and references with an RID', async () => {
+        const result = await getContent(session, 'TP53:p.1_23::BRCA2:p.4_56');
+        expect(result.type).toBe('#123:45');
+        expect(result.reference1).toBe('#123:46');
+        expect(result.reference2).toBe('#123:47');
+    });
+});
+
+describe('positionalVariantQueryFilters', () => {
+    test('only selected props as key-value pairs', () => {
+        expect(positionalVariantQueryFilters({
+            break1Repr: 'c.123',
+            break1Start: {
+                '@class': 'CdsPosition',
+                pos: 123,
+                prefix: 'c',
+                offset: 0,
+            }, // should be removed from query filter
+            reference1: '#123:45',
+            refSeq: 'C',
+            type: '#123:46',
+            untemplatedSeq: 'A',
+        })).toEqual({
+            AND: [
+                { break1Repr: 'c.123' },
+                { reference1: '#123:45' },
+                { refSeq: 'C' },
+                { type: '#123:46' },
+                { untemplatedSeq: 'A' },
+            ],
+        });
+    });
+});
+
+describe('uploadPositionalVariant', () => {
+    const session = {};
+    const user = { };
+
+    beforeEach(() => {
+        create.mockReset();
+        select.mockReset();
+    });
+
+    test('create new record, no RID lookup needed', async () => {
+        create.mockResolvedValue({ '@rid': '#21:1' });
+
+        const content = {
+            reference1: '#20:2',
+            reference2: '#20:3',
+            type: '#20:1',
+        };
+
+        await expect(
+            uploadPositionalVariant(
+                session,
+                user,
+                content,
+            ),
+        ).resolves.toEqual([{ '@rid': '#21:1' }, 'CREATED']);
+        expect(create).toHaveBeenCalledWith(session, {
+            content,
+            modelName: 'PositionalVariant',
+            user,
+        });
+        expect(select).not.toHaveBeenCalled();
+    });
+
+    test('conversion to RIDs and create new record', async () => {
+        create.mockResolvedValue({ '@rid': '#21:1' });
+        select
+            .mockResolvedValueOnce([{ '@rid': '#20:1' }]) // getType()
+            .mockResolvedValueOnce([{ '@rid': '#20:2', source: { name: 'hgnc' } }]) // getReference()
+            .mockResolvedValueOnce([{ '@rid': '#20:3', source: { name: 'hgnc' } }]); // getReference()
+
+        const content = {
+            reference1: 'BRCA2',
+            reference2: 'TP53',
+            type: 'deletion',
+        };
+
+        await expect(
+            uploadPositionalVariant(
+                session,
+                user,
+                content,
+            ),
+        ).resolves.toEqual([{ '@rid': '#21:1' }, 'CREATED']);
+        expect(create).toHaveBeenCalledWith(session, {
+            content: {
+                reference1: '#20:2',
+                reference2: '#20:3',
+                type: '#20:1',
+            },
+            modelName: 'PositionalVariant',
+            user,
+        });
+    });
+
+    test('returns existing record', async () => {
+        create.mockRejectedValue(new RecordConflictError({}));
+        select.mockResolvedValue([{ '@rid': '#21:1' }]);
+
+        await expect(
+            uploadPositionalVariant(
+                session,
+                user,
+                {
+                    reference1: '#20:2',
+                    type: '#20:1',
+                },
+            ),
+        ).resolves.toEqual([{ '@rid': '#21:1' }, 'OK']);
+    });
+
+    test('throws RecordConflictError when conflict', async () => {
+        const conflict = new RecordConflictError({});
+        create.mockRejectedValue(conflict);
+
+        await expect(
+            uploadPositionalVariant(
+                session,
+                user,
+                {
+                    reference1: '#20:2',
+                    type: '#20:1',
+                },
+                { existsOk: false },
+            ),
+        ).rejects.toBe(conflict);
+        expect(select).not.toHaveBeenCalled();
+    });
+});

--- a/test/repo/upload/positionalvariant.test.js
+++ b/test/repo/upload/positionalvariant.test.js
@@ -9,7 +9,7 @@ jest.mock('../../../src/repo/query_builder/index', () => ({
 }));
 
 jest.mock('../../../src/repo/error', () => ({
-    NotImplementedError: class NotImplementedError extends Error {
+    NoRecordFoundError: class NoRecordFoundError extends Error {
         constructor(obj) {
             super(obj.message);
             this.name = 'ValidationError';
@@ -33,7 +33,7 @@ jest.mock('../../../src/repo/error', () => ({
 const { create, select } = require('../../../src/repo/commands');
 const { parse } = require('../../../src/repo/query_builder/index');
 const {
-    NotImplementedError,
+    NoRecordFoundError,
     RecordConflictError,
     ValidationError,
 } = require('../../../src/repo/error');
@@ -91,10 +91,10 @@ describe('getTypeRID', () => {
         await expect(getTypeRID(session, 'substitution')).resolves.toBe('#123:45');
     });
 
-    test('throws NotImplementedError when vocabulary is not found', async () => {
+    test('throws NoRecordFoundError when vocabulary is not found', async () => {
         select.mockResolvedValue([]);
 
-        await expect(getTypeRID(session, 'unknown')).rejects.toBeInstanceOf(NotImplementedError);
+        await expect(getTypeRID(session, 'unknown')).rejects.toBeInstanceOf(NoRecordFoundError);
     });
 });
 
@@ -124,10 +124,10 @@ describe('getReferenceRID', () => {
         await expect(getReferenceRID(session, 'BRCA2', { preferedRefSrcName: 'entrez gene' })).resolves.toBe('#123:46');
     });
 
-    test('throws NotImplementedError when no feature is found', async () => {
+    test('throws NoRecordFoundError when no feature is found', async () => {
         select.mockResolvedValue([]);
 
-        await expect(getReferenceRID(session, 'BRCA2', {})).rejects.toBeInstanceOf(NotImplementedError);
+        await expect(getReferenceRID(session, 'BRCA2', {})).rejects.toBeInstanceOf(NoRecordFoundError);
     });
 });
 

--- a/test/repo/upload/positionalvariant.test.js
+++ b/test/repo/upload/positionalvariant.test.js
@@ -40,8 +40,8 @@ const {
 const {
     formatReferenceDisplayName,
     getContent,
-    getReference,
-    getType,
+    getReferenceRID,
+    getTypeRID,
     positionalVariantQueryFilters,
     uploadPositionalVariant,
 } = require('../../../src/repo/upload/positionalvariant');
@@ -69,7 +69,7 @@ describe('formatReferenceDisplayName', () => {
     });
 });
 
-describe('getType', () => {
+describe('getTypeRID', () => {
     const session = {};
 
     beforeEach(() => {
@@ -80,25 +80,25 @@ describe('getType', () => {
         jest.clearAllMocks();
     });
 
-    test('type is formatted to lowercase', async () => {
-        await getType(session, 'Substitution');
+    test('type arg gets formatted to lowercase', async () => {
+        await getTypeRID(session, 'Substitution');
         expect(parse).toHaveBeenCalledWith(expect.objectContaining({
             filters: { name: 'substitution' },
         }));
     });
 
     test('returns RID when vocabulary is found', async () => {
-        await expect(getType(session, 'substitution')).resolves.toBe('#123:45');
+        await expect(getTypeRID(session, 'substitution')).resolves.toBe('#123:45');
     });
 
     test('throws NotImplementedError when vocabulary is not found', async () => {
         select.mockResolvedValue([]);
 
-        await expect(getType(session, 'unknown')).rejects.toBeInstanceOf(NotImplementedError);
+        await expect(getTypeRID(session, 'unknown')).rejects.toBeInstanceOf(NotImplementedError);
     });
 });
 
-describe('getReference', () => {
+describe('getReferenceRID', () => {
     const session = {};
 
     beforeEach(() => {
@@ -110,24 +110,24 @@ describe('getReference', () => {
     });
 
     test('normalizes chromosome notation before querying', async () => {
-        await getReference(session, '12');
+        await getReferenceRID(session, '12');
         expect(parse).toHaveBeenCalledWith(expect.objectContaining({
             filters: { displayName: 'chr12' },
         }));
     });
 
     test('returns first RID when there is no preferedRefSrcName provided', async () => {
-        await expect(getReference(session, 'BRCA2', {})).resolves.toBe('#123:45');
+        await expect(getReferenceRID(session, 'BRCA2', {})).resolves.toBe('#123:45');
     });
 
     test('uses preferred source if preferedRefSrcName is provided', async () => {
-        await expect(getReference(session, 'BRCA2', { preferedRefSrcName: 'entrez gene' })).resolves.toBe('#123:46');
+        await expect(getReferenceRID(session, 'BRCA2', { preferedRefSrcName: 'entrez gene' })).resolves.toBe('#123:46');
     });
 
     test('throws NotImplementedError when no feature is found', async () => {
         select.mockResolvedValue([]);
 
-        await expect(getReference(session, 'BRCA2', {})).rejects.toBeInstanceOf(NotImplementedError);
+        await expect(getReferenceRID(session, 'BRCA2', {})).rejects.toBeInstanceOf(NotImplementedError);
     });
 });
 
@@ -137,9 +137,9 @@ describe('getContent', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         select
-            .mockResolvedValueOnce([{ '@rid': '#123:45' }]) // getType()
-            .mockResolvedValueOnce([{ '@rid': '#123:46', source: { name: 'hgnc' } }]) // getReference()
-            .mockResolvedValueOnce([{ '@rid': '#123:47', source: { name: 'hgnc' } }]); // getReference()
+            .mockResolvedValueOnce([{ '@rid': '#123:45' }]) // getTypeRID()
+            .mockResolvedValueOnce([{ '@rid': '#123:46', source: { name: 'hgnc' } }]) // getReferenceRID()
+            .mockResolvedValueOnce([{ '@rid': '#123:47', source: { name: 'hgnc' } }]); // getReferenceRID()
     });
 
     test('throws ValidationError when notation is empty string', async () => {
@@ -216,9 +216,9 @@ describe('uploadPositionalVariant', () => {
     test('conversion to RIDs and create new record', async () => {
         create.mockResolvedValue({ '@rid': '#21:1' });
         select
-            .mockResolvedValueOnce([{ '@rid': '#20:1' }]) // getType()
-            .mockResolvedValueOnce([{ '@rid': '#20:2', source: { name: 'hgnc' } }]) // getReference()
-            .mockResolvedValueOnce([{ '@rid': '#20:3', source: { name: 'hgnc' } }]); // getReference()
+            .mockResolvedValueOnce([{ '@rid': '#20:1' }]) // getTypeRID()
+            .mockResolvedValueOnce([{ '@rid': '#20:2', source: { name: 'hgnc' } }]) // getReferenceRID()
+            .mockResolvedValueOnce([{ '@rid': '#20:3', source: { name: 'hgnc' } }]); // getReferenceRID()
 
         const content = {
             reference1: 'BRCA2',


### PR DESCRIPTION
New upload/hgvs POST route
Parse an HGVS-like variant notation, and fetch type and references RIDs so the content is uploadable.
The upload itself is optional (default).

Documentation in /spec#tag/General/paths/~1upload~1hgvs/post
