### PR TITLE
Task/kbdev 1537 update fulltext queries

### DIFF
--- a/src/repo/model.js
+++ b/src/repo/model.js
@@ -130,7 +130,11 @@ const createModelInDb = async (modelName, db, opt = {}) => {
                     return;
                 }
             }
-            logger.info(`creating index ${index.name} type ${index.type}`);
+            if (index.engine) {
+                logger.info(`creating index ${index.name} type ${index.type} engine ${index.engine}`);
+            } else {
+                logger.info(`creating index ${index.name} type ${index.type}`);
+            }
             await db.index.create(index);
         };
         await Promise.all(

--- a/src/repo/model.js
+++ b/src/repo/model.js
@@ -130,11 +130,8 @@ const createModelInDb = async (modelName, db, opt = {}) => {
                     return;
                 }
             }
-            if (index.engine) {
-                logger.info(`creating index ${index.name} type ${index.type} engine ${index.engine}`);
-            } else {
-                logger.info(`creating index ${index.name} type ${index.type}`);
-            }
+            // eslint-disable-next-line multiline-ternary
+            logger.info(`creating index ${index.name} type ${index.type}${index.engine ? ` engine ${index.engine}` : ''}`);
             await db.index.create(index);
         };
         await Promise.all(

--- a/src/repo/model.js
+++ b/src/repo/model.js
@@ -94,6 +94,24 @@ const createModelInDb = async (modelName, db, opt = {}) => {
             async (prop) => createPropertyInDb(prop, cls),
         ));
     }
+
+    // KBDEB-1537. Adding Ontology.name_sourceId FULLTEXT LUCENE index
+    if (modelName === 'Ontology') {
+        if (!model.indices) {
+            model.indices = [];
+        }
+        model.indices.push({
+            class: 'Ontology',
+            engine: 'LUCENE',
+            metadata: {
+                analyzer: 'org.apache.lucene.analysis.standard.StandardAnalyzer',
+            },
+            name: 'Ontology.name_sourceId',
+            properties: ['name', 'sourceId'],
+            type: 'FULLTEXT',
+        });
+    }
+
     if (indices) {
         const createIndex = async (index) => {
             let exists = false;
@@ -111,10 +129,6 @@ const createModelInDb = async (modelName, db, opt = {}) => {
                     logger.info(`index exists ${index.name}`);
                     return;
                 }
-            }
-            if (!index.engine && index.type === 'FULLTEXT') {
-                // TODO: https://www.bcgsc.ca/jira/browse/SYS-58339 pending db update to 3.1
-                // index.engine = 'LUCENE';
             }
             logger.info(`creating index ${index.name} type ${index.type}`);
             await db.index.create(index);

--- a/src/repo/query_builder/fixed.js
+++ b/src/repo/query_builder/fixed.js
@@ -325,7 +325,17 @@ const singleKeywordSearch = ({
             OR sourceId ${operator} :${param}
             OR source.name ${operator} :${param}
             OR displayName.toLowerCase() ${operator} :${param}`;
-    } if (schemaDefn.inheritsFrom(model.name, 'Ontology') || model.name === 'Ontology' || model.name === 'Evidence') {
+    } if (schemaDefn.inheritsFrom(model.name, 'Ontology') || model.name === 'Ontology') {
+        if (operator === OPERATORS.CONTAINSTEXT) {
+            return `SELECT *
+            FROM ${targetQuery || model.name}
+            WHERE SEARCH_FIELDS(['name','sourceId'], :${param}) = true`;
+        }
+        return `SELECT *
+        FROM ${targetQuery || model.name}
+        WHERE name ${operator} :${param}
+            OR sourceId ${operator} :${param}`;
+    } if (model.name === 'Evidence') {
         return `SELECT *
         FROM ${targetQuery || model.name}
         WHERE name ${operator} :${param}

--- a/src/repo/schema.js
+++ b/src/repo/schema.js
@@ -123,6 +123,7 @@ const createSchema = async (db) => {
         async (prop) => createPropertyInDb(prop, E),
     ));
 
+    // TODO: Should these indices be defined in the schema instead?
     await Promise.all(Array.from(['E', 'V', 'User'], (cls) => db.index.create({
         class: cls,
         metadata: { ignoreNullValues: false },
@@ -131,6 +132,7 @@ const createSchema = async (db) => {
         type: 'unique',
     })));
     logger.log('info', 'defined schema for the major base classes');
+
     // create the other schema classes
     const classesByLevel = schema.splitClassLevels().slice(1);
 

--- a/test/db_integration/queries.test.js
+++ b/test/db_integration/queries.test.js
@@ -112,11 +112,7 @@ describeWithAuth('query builder', () => {
         });
     });
 
-    // KBDEV-1426. Skipping keyword queryType tests for OrientDB != 3.0
-    (process.env.ORIENTDB_VERSION === '3.0' || process.env.ORIENTDB_VERSION === undefined
-        ? describe
-        : describe.skip
-    )('selectByKeyword', () => {
+    describe('selectByKeyword', () => {
         test('get from related variant reference', async () => {
             const query = parse({ keyword: 'kras', queryType: 'keyword', target: 'Statement' });
             const result = await select(session, query);

--- a/test/db_integration/query_routes.test.js
+++ b/test/db_integration/query_routes.test.js
@@ -111,11 +111,7 @@ describeWithAuth('api read-only routes', () => {
         });
     });
 
-    // KBDEV-1426. Skipping keyword queryType tests for OrientDB != 3.0
-    (process.env.ORIENTDB_VERSION === '3.0' || process.env.ORIENTDB_VERSION === undefined
-        ? describe
-        : describe.skip
-    )('/query search statements by keyword', () => {
+    describe('/query search statements by keyword', () => {
         test('count ignores limit', async () => {
             const response = await request({
                 body: {


### PR DESCRIPTION
Right now, only Ontology have FULLTEXT indexes, and this PR is only adding a LUCENE index to that class.

But there is possibility to do CONTAINSTEXT queries (so leveraging FULLTEXT sql queries) on other class too (like variants), and this default to a 'per record scan' from what I'm understanding.